### PR TITLE
Avoid nested arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const getAllCerts = (readSync = false) => {
         try {
           certPath = path.resolve(__dirname, certPath);
           const file = fs.readFileSync(certPath, "utf-8");
-          certs.push(file.split(splitPattern).map(cert => cert));
+          certs.push(...file.split(splitPattern).map(cert => cert));
           resolve(certs);
         } catch (err) {
           if (err.code !== "ENOENT") {
@@ -40,7 +40,7 @@ const getAllCerts = (readSync = false) => {
             }
             ++rejectedPaths;
           } else {
-            certs.push(file.split(splitPattern).map(cert => cert));
+            certs.push(...file.split(splitPattern).map(cert => cert));
             resolve(certs);
           }
         });


### PR DESCRIPTION
I am not sure if this an error or not, but `getAllCerts` methods returns all certs in nested array, something like:

```
[[cert1, cert2, ...]]
```

I am wondering if this is on purpose or not. I did not expect that and it took  me a while to figure out what was wrong when I was assuming a response as 

```
[cert1, cert2, ...]
```

I am a noob on JavaScript so I might be missing some details, but I would have expected the library to be coded as in this PR.

Signed-off-by: David Cassany <dcassany@suse.com>